### PR TITLE
Potential fix for code scanning alert no. 10: Server-side request forgery

### DIFF
--- a/src/fetchers/wakatime.js
+++ b/src/fetchers/wakatime.js
@@ -7,16 +7,37 @@ import { CustomError, MissingParamError } from "../common/utils.js";
  * @param {{username: string, api_domain: string }} props Fetcher props.
  * @returns {Promise<WakaTimeData>} WakaTime data response.
  */
+// Allow-list of permitted WakaTime API domains
+const ALLOWED_API_DOMAINS = ["wakatime.com"];
+// Add more allowed domains as needed, e.g. for enterprise customers
+const USERNAME_REGEX = /^[A-Za-z0-9-_]+$/;
+
 const fetchWakatimeStats = async ({ username, api_domain }) => {
   if (!username) {
     throw new MissingParamError(["username"]);
   }
+  if (!USERNAME_REGEX.test(username)) {
+    throw new CustomError(
+      "Invalid username format.",
+      "WAKATIME_USERNAME_INVALID",
+    );
+  }
+  let apiHost = "wakatime.com";
+  if (api_domain) {
+    // Validate against allowlist
+    const sanitizedDomain = api_domain.replace(/\/$/gi, "");
+    if (!ALLOWED_API_DOMAINS.includes(sanitizedDomain)) {
+      throw new CustomError(
+        `Invalid API domain '${sanitizedDomain}'.`,
+        "WAKATIME_API_DOMAIN_INVALID",
+      );
+    }
+    apiHost = sanitizedDomain;
+  }
 
   try {
     const { data } = await axios.get(
-      `https://${
-        api_domain ? api_domain.replace(/\/$/gi, "") : "wakatime.com"
-      }/api/v1/users/${username}/stats?is_including_today=true`,
+      `https://${apiHost}/api/v1/users/${username}/stats?is_including_today=true`,
     );
 
     return data.data;


### PR DESCRIPTION
Potential fix for [https://github.com/marcschaeferger/github-readme-stats/security/code-scanning/10](https://github.com/marcschaeferger/github-readme-stats/security/code-scanning/10)

To fix the SSRF vulnerability, both inputs (`api_domain`, `username`) must be validated before forming the outgoing URL.

- For `api_domain`, use an **allow-list** of permitted domains if custom domains are truly needed; otherwise, do not allow user customization of the domain at all (i.e., only support the default `"wakatime.com"`). If you need to permit a set of WakaTime enterprise domains, specify them explicitly.
- For `username`, ensure it matches a pattern matching GitHub usernames: e.g., `/^[A-Za-z0-9-_]+$/` and forbid slashes, backslashes, dots, or other path traversal mechanisms.
- Implement these checks in `fetchWakatimeStats` in `src/fetchers/wakatime.js`, immediately after receiving arguments but before constructing the URL.
- If `api_domain` is not on the allow-list or matches a forbidden pattern, throw an error.
- If `username` does not match the required regular expression, throw an error.

We will use an `ALLOWED_API_DOMAINS` array in `src/fetchers/wakatime.js`. Only these hosts will be permitted. If more flexibility is required (e.g., subdomains), the allow-list logic can be expanded, but should remain strict.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
