### PR TITLE
Potential fix for code scanning alert no. 29: Reflected cross-site scripting

### DIFF
--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -116,10 +116,10 @@ export default async (req, res) => {
     ); // Use lower cache period for errors.
     return res.send(
       renderError(err.message, err.secondaryMessage, {
-        title_color,
-        text_color,
-        bg_color,
-        border_color,
+        title_color: sanitizeColor(title_color),
+        text_color: sanitizeColor(text_color),
+        bg_color: sanitizeColor(bg_color),
+        border_color: sanitizeColor(border_color),
         theme,
       }),
     );


### PR DESCRIPTION
Potential fix for [https://github.com/marcschaeferger/github-readme-stats/security/code-scanning/29](https://github.com/marcschaeferger/github-readme-stats/security/code-scanning/29)

To fix the reflected XSS, all user-provided color values passed as card options should be sanitized before being used as SVG attributes. Specifically for error case handling (`renderError` in `api/wakatime.js`), wrap every incoming color option with the `sanitizeColor` function when building the options object, before rendering or passing into downstream code. This can be done directly in the catch block in `api/wakatime.js` by changing lines 117–125 so every color field is sanitized by `sanitizeColor`. Since `sanitizeColor` is imported from `src/common/utils.js`, there's no need to add new imports; simply wrap each color (e.g., `sanitizeColor(title_color)`). No change in functional API or data flow should result—merely additional security checks.

You may also need to confirm that other places invoking `renderError` or rendering cards with user-provided color values apply the sanitizer, but per the detected flow, the primary change is in the error handling branch.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
